### PR TITLE
Add a save_timeout entry to the config

### DIFF
--- a/priv/development.config
+++ b/priv/development.config
@@ -16,6 +16,7 @@
       {lock_conf, []},
       {lock_timeout_interval, 60000},
       {message_timeout, 50000},
+      {save_timeout, 50000},
       {stats_mod, wes_stats_ets}]
      ]}
   ]},


### PR DESCRIPTION
Avoids a badarith error on the wes_timeout:add function
